### PR TITLE
Fix ID extraction for CRUD operations

### DIFF
--- a/DynamicToolRegistry.cs
+++ b/DynamicToolRegistry.cs
@@ -655,8 +655,9 @@ public class DynamicToolRegistry
 
     private async Task<object> ExecuteReadAsync(HttpClient client, DynamicTool tool, Dictionary<string, object> input)
     {
-        if (!input.TryGetValue("id", out var idObj) || idObj is not string id || string.IsNullOrWhiteSpace(id))
+        if (!input.TryGetValue("id", out var idObj) || string.IsNullOrWhiteSpace(idObj?.ToString()))
             throw new ArgumentException("ID is required for read operation");
+        var id = idObj.ToString();
 
         var path = tool.ApiPath.Replace("{id}", id);
         var response = await client.GetAsync(path);


### PR DESCRIPTION
## Summary
- fix ID validation pattern in CRUD helpers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846e6354d048321815f170ab4f1575c